### PR TITLE
Support HUB SPOKE MS Ref Arch regarding Remote Gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,21 @@ module "vnetpeering" {
   }
 }
 
+# Create VNET peering from Second VNET to First VNET (reciprocal) - hub-spoke architecture, outbound remote gateway
+module "vnetpeering" {
+  source				= "../.."
+  vnet_peering_names                    = ["${azurerm_resource_group.spoke.name}-peer", "${azurerm_resource_group.hub.name}-peer"]
+  vnet_names                            = ["${module.vnetspoke.vnet_name}", "${module.vnethub.vnet_name}"]
+  resource_group_names                  = ["${azurerm_resource_group.spoke.name}", "${azurerm_resource_group.hub.name}"]
+  allow_virtual_network_access          = true
+  allow_forwarded_traffic               = true
+  allow_gateway_transit                 = true
+  use_remote_gateways_outbound          = true
+  use_remote_gateways_inbound           = false
+
 
 ```
+
 
 ## Test
 

--- a/main.tf
+++ b/main.tf
@@ -44,7 +44,7 @@ resource "azurerm_virtual_network_peering" "vnet_peer_1" {
   remote_virtual_network_id    = "${data.azurerm_virtual_network.vnet2.id}"
   allow_virtual_network_access = "${var.allow_virtual_network_access}"
   allow_forwarded_traffic      = "${var.allow_forwarded_traffic}"
-  use_remote_gateways          = "${var.use_remote_gateways}"
+  use_remote_gateways          = "${var.use_remote_gateways_outbound}"
 }
 
 resource "azurerm_virtual_network_peering" "vnet_peer_2" {
@@ -54,5 +54,5 @@ resource "azurerm_virtual_network_peering" "vnet_peer_2" {
   remote_virtual_network_id    = "${data.azurerm_virtual_network.vnet1.id}"
   allow_virtual_network_access = "${var.allow_virtual_network_access}"
   allow_forwarded_traffic      = "${var.allow_forwarded_traffic}"
-  use_remote_gateways          = "${var.use_remote_gateways}"
+  use_remote_gateways          = "${var.use_remote_gateways_inbound}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -39,8 +39,13 @@ variable "allow_gateway_transit" {
   default     = true
 }
 
-variable "use_remote_gateways" {
-  description = "(Optional) Controls if remote gateways can be used on the local virtual network. If the flag is set to true, and allow_gateway_transit on the remote peering is also true, virtual network will use gateways of remote virtual network for transit. Defaults to false."
+variable "use_remote_gateways_outbound" {
+  description = "(Optional) Controls if remote gateways can be used on the local network - only peer1 to peer2"
+  default     = false
+}
+
+variable "use_remote_gateways_inbound" {
+  description = "(Optional) Controls if remote gateways can be used on the local network - only peer2 to peer1"
   default     = false
 }
 


### PR DESCRIPTION
Reference hub-spoke architecture expects that peering connection from SPOKE to HUB will use remote gateway, but no remote gateway will exist in spoke vnet. Basic extension to handle inbound v outbound setting for remote gateways for mutual peering connection